### PR TITLE
update typewriter to be aware of game state. Bugfixes in Scriptexample.

### DIFF
--- a/Assets/GameScript/ScriptExample.xml
+++ b/Assets/GameScript/ScriptExample.xml
@@ -11,15 +11,15 @@
 
   <!-- id for dSets should be assigned by another tool. -->
   <dialogue>
-    <!-- DSet is a dialougue set. Group of dialouge related in some fashion -> a set of dialouge to play after a stat check, plays under a specific circumstance, etc -->
+    <!-- dset is a dialougue set. Group of dialouge related in some fashion -> a set of dialouge to play after a stat check, plays under a specific circumstance, etc -->
     <!-- options for pulling the next tag: [sequential, random, wRandom] wRandom requires weights to be assigned to each line -->
-    <dSet id="1" code="Human Readable name" pull="sequential" textSpeed="1" >
+    <dset id="1" code="Human Readable name" pull="sequential" textSpeed="1">
 
       <!-- text speed not required here, but will override parent -->
       <!-- playSound, playMusic, playAnim, prePuase optional -->
       <!-- if "hasBeenPlayed is not specified, it's expected false. This will oly be updated via code"-->
       <line textSpeed="2" speakerId="ZUES" playAnim="ZUES_SURP.anim" prePause ="0.1" hasBeenPlayed="true">
-        <text prePause="0.3" textSound="overideSpeakerTextSoundHere">
+        <text textSpeed="1" prePause="0.3" textSound="overideSpeakerTextSoundHere">
           Lorem ipsum dolor sit <i>amet</i>, consectetur <color hex="#AE1234">adipiscing</color> elit,
         </text>
         <text prePause="0" textSpeed="1">sed do eiusmod tempor incididunt ut labore...</text>
@@ -38,11 +38,11 @@
         <text>Sed ut perspiciatis unde omnis iste natus error sit voluptatem... </text>
         <text>accusantium doloremque laudantium, totam rem aperiam,</text>
       </line>
-    </dSet>
+    </dset>
 
 
     <!-- dSets can also allow branching based on facts about the world. No branch means we expect the main path -->
-    <dSet id="2" code="DEFINED_CODE_SYSTEM_TO_AVOID_CONFLICTS" pull="sequential">
+    <dset id="2" code="DEFINED_CODE_SYSTEM_TO_AVOID_CONFLICTS" pull="sequential">
       <line textSpeed="2" speakerId="ZUES" playAnim="ZUES_SURP.anim" prePause ="0.1">
         <text>sed do eiusmod tempor incididunt ut labore...</text>
       </line>
@@ -50,7 +50,7 @@
       <branch>
         <path checkType="any">
             <check fact="FACT_CODE" op="gt" val="4"/>
-            <check factId="1" op="gt" val="4"/>
+            <check fact="1" op="gt" val="4"/>
             <check fact="FACT_CODE2" op="eq" val="1"/>
             <check fact="FACT_CODE3" op="lte" val="1"/>
             <line speakerId="ZUES">
@@ -68,7 +68,7 @@
         <branch>
           <path checkType="any">
             <check fact="FACT_CODE" op="gt" val="4"/>
-            <check factId="1" op="gt" val="4"/>
+            <check fact="1" op="gt" val="4"/>
             <check fact="FACT_CODE2" op="eq" val="1"/>
             <check fact="FACT_CODE3" op="lte" val="1"/>
             <line>
@@ -91,7 +91,7 @@
       <branch>
         <path checkType="any">
           <check fact="FACT_CODE" op="gt" val="4"/>
-          <check factId="1" op="gt" val="4"/>
+          <check fact="1" op="gt" val="4"/>
           <check fact="FACT_CODE2" op="eq" val="1"/>
           <check fact="FACT_CODE3" op="lte" val="1"/>
           <line speakerId="DUES">
@@ -105,7 +105,7 @@
           <branch>
             <path checkType="any">
               <check fact="FACT_CODE" op="gt" val="4"/>
-              <check factId="1" op="gt" val="4"/>
+              <check fact="1" op="gt" val="4"/>
               <check fact="FACT_CODE2" op="eq" val="1"/>
               <check fact="FACT_CODE3" op="lte" val="1"/>
               <line speakerId="NABLE">
@@ -117,25 +117,25 @@
           
         </path>
       </branch>
-    </dSet>
+    </dset>
   
     <!-- dSets can make references to other dSets in OTHER files by their id or name, allowing intercutting, GIVEN THEY ARE REFERENCED IN INCLUDE OR INCLUDE TAG -->
-    <dSet id="5" code="DEFINED_CODE_SYSTEM_TO_AVOID_CONFLICTS" pull="sequential">
+    <dset id="5" code="DEFINED_CODE_SYSTEM_TO_AVOID_CONFLICTS" pull="sequential">
       <line>
         <text>Nam libero tempore, cum soluta nobis est eligendi</text>
-        <innerRef id="1"/> <!-- a reference to a dSet WITHIN this document -->
+        <innerRef id="1"/> <!-- a reference to a dset WITHIN this document -->
         <text>Giga Benis,</text>
 
-        <externalRef code="9"/><!-- a ref to an external dSet. It is CRITICAL that ids and codes are unique!!!-->
+        <externalRef code="9"/><!-- a ref to an external dset. It is CRITICAL that ids and codes are unique!!!-->
         <externalRef path="ScriptExample2.xml"/>
       </line>
-    </dSet>
+    </dset>
     
     <!-- finally, dSets also need to allow display a set of choices that, usually, update facts. These facts have scope, scene, temp, global-->
     <!-- options must be able to be hidden based on facts-->
     <!-- all or any choice checks must pass in order to SELECT a choice -->
     <!-- all or any display checks must pass to be able to SEE a choice at all -->
-    <dSet id="5" code="DEFINED_CODE_SYSTEM_TO_AVOID_CONFLICTS" pull="sequential">
+    <dset id="5" code="DEFINED_CODE_SYSTEM_TO_AVOID_CONFLICTS" pull="sequential">
       <choice>
         <option displayCheckType="any" choiceCheckType="any">
           <choiceCheck fact="FACT_CODE" op="gt" val="17"/>
@@ -147,7 +147,7 @@
           <choiceCheck fact="FACT_CODE2" op="eq" val="1"/>
           <displayCheck fact="FACT_CODE3" op="lte" val="1" />
           <text>option display text2</text>
-          <update factId="3" set="++"/>
+          <update fact="3" set="++"/>
         </option>
       </choice>
 
@@ -178,19 +178,21 @@
       <line>
         <text>back to main branch line</text>
       </line>
-    </dSet>
+    </dset>
 
     
       
     <!-- dSets can update a specfic fact about the world. -->
-    <dSet id="5" code="DEFINED_CODE_SYSTEM_TO_AVOID_CONFLICTS" pull="sequential">
+    <!-- update by fact name is not implmented yet. -->
+    <dset id="5" code="DEFINED_CODE_SYSTEM_TO_AVOID_CONFLICTS" pull="sequential">
       <line>
         <text>Nam libero tempore, cum soluta nobis est eligendi</text>
-        <update factId="3" set="++"/>
-        <update factName="YouCanAlsoUseAFactCode" set="--"/>
-        <update factId="5" set="7"/>
+        <update fact="3" set="++"/>
+        <!--  <update factName="YouCanAlsoUseAFactCode" set="++"/> -->
+       
+        <update fact="5" set="7"/>
       </line>
-    </dSet>
+    </dset>
   </dialogue>
 
 

--- a/Assets/GameScript/Tests/check_basic_line_ordering.xml
+++ b/Assets/GameScript/Tests/check_basic_line_ordering.xml
@@ -13,7 +13,7 @@
   <dialogue>
     <!-- dset is a dialougue set. Group of dialouge related in some fashion -> a set of dialouge to play after a stat check, plays under a specific circumstance, etc -->
     <!-- options for pulling the next tag: [sequential, random, wRandom] wRandom requires weights to be assigned to each line -->
-    <dset id="0" code="Human Readable name" pull="sequential" textSpeed="1" >
+    <dset id="1" code="Human Readable name" pull="sequential" textSpeed="1" >
 
       <!-- text speed not required here, but will override parent -->
       <!-- playSound, playMusic, playAnim, prePuase optional -->

--- a/Assets/Scripts/Debug/SpeachTester.cs
+++ b/Assets/Scripts/Debug/SpeachTester.cs
@@ -13,9 +13,11 @@ public class SpeachTester : MonoBehaviour
     void Start()
     {
 
-        // SceneWeaver.GetInstance().LoadScene("Tests/TestFactsUpdateByLine 1");
+        // SceneWeaver.GetInstance().LoadScene("Tests/TestFactsUpdateByLine_1");
+        // SceneWeaver.GetInstance().LoadScene("ScriptExample");
+        // SceneWeaver.GetInstance().LoadScene("Tests/check_basic_line_ordering");
         SceneWeaver.GetInstance().LoadScene("Tests/TestChoicesAndLinesRender");
-        //SceneWeaver.GetInstance().LoadScene("Tests/check_basic_line_ordering");
+
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/TextSystem/Constants.cs
+++ b/Assets/Scripts/TextSystem/Constants.cs
@@ -9,9 +9,9 @@ namespace Assets.Scripts.TextSystem
     class Constants
     {
         public const float DEFAULT_CHARACTERS_PER_SEC = 6f;
-        public readonly Dictionary<string, float> characterToTypeWriterPrePause = new Dictionary<string, float>()
+        public static readonly Dictionary<string, float> CHARACTER_TO_PREPAUSE = new Dictionary<string, float>()
         {
-            { ",", 1f},
+            { ",", 0.3f},
             { "...", 1f},
             { ";", 1f},
             {"--", 1f }

--- a/Assets/Scripts/TextSystem/Models/Dialogue/DialogueLine.cs
+++ b/Assets/Scripts/TextSystem/Models/Dialogue/DialogueLine.cs
@@ -49,7 +49,14 @@ namespace Assets.Scripts.TextSystem.Models.Dialogue
                 // TODO pull from parent
             }
 
-            this.SpeakerId = lineXML.Attributes["speakerId"].Value;
+            if(lineXML.Attributes["speakerId"] == null)
+            {
+                this.SpeakerId = "SYSTEM";
+            } else
+            {
+                this.SpeakerId = lineXML.Attributes["speakerId"].Value;
+            }
+            
 
             foreach (XmlNode lineXMLChild in lineXML.ChildNodes)
             {

--- a/Assets/Scripts/TextSystem/Models/Dialogue/DialogueSet.cs
+++ b/Assets/Scripts/TextSystem/Models/Dialogue/DialogueSet.cs
@@ -75,7 +75,10 @@ namespace Assets.Scripts.TextSystem.Models.Dialogue
         {
             this.Id = Int32.Parse(dSetNode.Attributes["id"].Value);
             this.Code = dSetNode.Attributes["code"].Value;
-            this.TextSpeed = float.Parse(dSetNode.Attributes["textSpeed"]?.Value); // textSpeed optional
+            if(float.TryParse(dSetNode.Attributes["textSpeed"]?.Value, out float textSpeed)){
+                this.TextSpeed = textSpeed;
+            }
+
             string pullType = dSetNode.Attributes["pull"]?.Value;
             
             foreach (XmlNode dSetChildXML in dSetNode.ChildNodes)

--- a/Assets/Scripts/TextSystem/SceneWeaver/SceneWeaver.cs
+++ b/Assets/Scripts/TextSystem/SceneWeaver/SceneWeaver.cs
@@ -98,6 +98,10 @@ namespace Assets.Scripts.TextSystem.SceneWeaver {
         public void ChooseOption(OptionDialogueNode chosenOption)
         {
             FactLibrary.GetInstance().UpdateFacts(chosenOption.FactUpdates);
+            // TODO -> head to the path determined by clicking a choice.
+            // TODO -> need to notify Typewriter to stop awaiting choice.
+
+
             // TODO: handle choices in DSet:
             // currentPathNode = chosenOption.NextPathNode;
             // we need to inject the view with new choice, but new path is DOne

--- a/Assets/Scripts/UI/Monobehaviors/UIController.cs
+++ b/Assets/Scripts/UI/Monobehaviors/UIController.cs
@@ -50,31 +50,36 @@ public class UIController : MonoBehaviour
 
     public void InsertNextDialogueElement(int dSetId)
     {
-        if (typeWriter.isWriting)
+        if (typeWriter.isWriting || typeWriter.IsAwaitingChoice)
         {
-            typeWriter.FinishLine();
+            // typeWriter.FinishLine(); -> only finish line based on a setting in game. Some game designs will not allow dialogue to finish, others will.
             return;
         }
 
         IDialogueModel line = SceneWeaver.GetInstance().GetNextDialogueElement(dSetId); // we don't want to call this when we see a choice!!!
         if (line is null) return;
 
+        // todo -> this is DEFINTELY broken lol
         if (line.IsFinalNodeInDSet)
         {
             Debug.LogWarning("FINAL NODE IN DSET DELIVERED. TODO:HANDLE THIS");
         }
+
         manager.InsertVisualElementIntoDialogueSecition(line.Renderer.GetVisualElement()); // must insert the new line first
         if (line is DialogueLine)
         {
-            
-            typeWriter.SetDLine((DialogueLine)line);
+            typeWriter.BeginTypeWriting((DialogueLine)line);
+        } else if(line is ChoiceSet)
+        {
+            // make it so we can ONLY progress on click.
+            typeWriter.IsAwaitingChoice = true;
         }
     }
 
     // TODO -> not properly set up to fire.
     public void OnDialogueSetExhausted(object source, System.EventArgs e)
     {
-        typeWriter.SetDLine(new DialogueLine("DSET IS EMPTY. RETURN TO GAMEPLAY")); // todo -> make this debug only
+        typeWriter.BeginTypeWriting(new DialogueLine("DSET IS EMPTY. RETURN TO GAMEPLAY")); // todo -> make this debug only
     }
 
     // TODO


### PR DESCRIPTION
The following has been fixed:
- "dSet" has been updated to "dset" in some xml samples. Worth investing time in a case unsensitive parser (requires work against c# xml parser
- various null checking for xml attributes have been fixed to make them actually optional.
- text speed now prioritizes the most specific in the XML. Text tags overwrite their line tags
- a pause has been added after certain characters or group of characters have been detected by typewriter
- audio blip will not play on whitespace text
- typewriter now waits for choices to be chosen before allowing someone to continue requesting for next dialogue
- typewriter will now require a line to finish before requesting the next line