### PR TITLE
heh, whoops. Add a check for already clicking a choice

### DIFF
--- a/Assets/GameScript/Tests/check_choices may_branch.xml
+++ b/Assets/GameScript/Tests/check_choices may_branch.xml
@@ -34,11 +34,15 @@
       <branch>
         <path checkType="any">
           <check fact="fact_000" op="eq" val="0"/>
-          <line>This branch should show.</line>
+          <line textSpeed="4" speakerId="Whoever2">
+            <text>this branch should show</text>
+          </line>
         </path>
         <path checkType="any">
           <check fact="fact_000" op="eq" val="120"/>
-          <line>This branch should not show.</line>
+          <line textSpeed="4" speakerId="Whoever2">
+            <text>this branch should not show</text>
+          </line>
         </path>
       </branch>
       

--- a/Assets/Scripts/TextSystem/Models/Choices/ChoiceSet.cs
+++ b/Assets/Scripts/TextSystem/Models/Choices/ChoiceSet.cs
@@ -31,6 +31,7 @@ namespace Assets.Scripts.TextSystem.Choices
         {
             // uh this is jank, but our UI controller expects a choiceSet to be it's dialogue element. Needs a refactor (but later) :)
             // for later refactor, allow the ChoiceSet to contain to DialogueLine that has all of the rendering info in it.
+            
             return this;
 
         }

--- a/Assets/Scripts/TextSystem/Models/Choices/OptionDialogueNode.cs
+++ b/Assets/Scripts/TextSystem/Models/Choices/OptionDialogueNode.cs
@@ -28,6 +28,7 @@ namespace Assets.Scripts.TextSystem.Choices
         public List<FactBasedTextRule> displayRules { get; set; }
         public string displayText { get; set; }
         public Enums.TextSystemEnums.OptionNodeGotoType OptionGotoType;
+        public bool HasBeenClicked { get; set; } = true;
 
         public OptionDialogueNode() : base()
         {
@@ -213,8 +214,12 @@ namespace Assets.Scripts.TextSystem.Choices
 
         public void OnClick()
         {
-            UIController.Instance.InsertNextDialogueElementFromChoice(this, 1);
-            Debug.Log($"Chose option:{this.IdxInParentNode} -- {this.displayText}");
+            if (HasBeenClicked)
+            {
+                UIController.Instance.InsertNextDialogueElementFromChoice(this, 1);
+                this.HasBeenClicked = false;
+                Debug.Log($"Chose option:{this.IdxInParentNode} -- {this.displayText}");
+            }
         }
 
 

--- a/Assets/Scripts/TextSystem/Models/Dialogue/DialogueSet.cs
+++ b/Assets/Scripts/TextSystem/Models/Dialogue/DialogueSet.cs
@@ -229,8 +229,6 @@ namespace Assets.Scripts.TextSystem.Models.Dialogue
                 dNodeList[currentDNodeIdx].ResetDElementsIdx();
                 
                 var nextDNode = dNodeList[currentDNodeIdx].GetNextNodePath(); // choose neighbor based on facts.
-
-                
                 
                 // will be null when we see there is a new path node, BUT nothing on that path can be chosen. We just want to continue past it.
                 if (nextDNode is null)
@@ -243,7 +241,9 @@ namespace Assets.Scripts.TextSystem.Models.Dialogue
                     }
                     return;
                 }
-                if (nextDNode.SkipToNextPathNode && !(dNodeList[currentDNodeIdx] is ChoiceSet))
+
+                
+                if ((nextDNode.SkipToNextPathNode || nextDNode.NextDialogueElements.Count == 0) && !(dNodeList[currentDNodeIdx] is ChoiceSet) )
                 {
                     Next();
                     return;
@@ -259,7 +259,7 @@ namespace Assets.Scripts.TextSystem.Models.Dialogue
 
                 // handle the case we see a skip node.
                 // er... need to fix this bc this is messy,, but choiceSets shouldn't be skipped...
-                if (dNodeList[currentDNodeIdx].SkipToNextPathNode && !(dNodeList[currentDNodeIdx] is ChoiceSet))
+                if ((dNodeList[currentDNodeIdx].SkipToNextPathNode || dNodeList[currentDNodeIdx].NextDialogueElements.Count == 0) && !(dNodeList[currentDNodeIdx] is ChoiceSet))
                 {
                     // in the case we see a skip node, just re-run Next.
                     Next();


### PR DESCRIPTION
Unity's new button's in UIBuilder after being clicked with continue to be clicked if you press enter or spacebar. This is... a stupid choice by them, but regardless, quick fix to make secondary clicks do nothing after first click.