### PR TITLE
Feature/fire events from xml

### DIFF
--- a/Assets/GameScript/Tests/check_choices may_branch.xml
+++ b/Assets/GameScript/Tests/check_choices may_branch.xml
@@ -8,7 +8,7 @@
   </line>
   <choice>
     <option displayCheckType="any" chooseCheckType="any">
-      <choiceCheck fact="FACT_CODE" op="gt" val="17"/>
+      <displayCheck fact="fact_000" op="gt" val="17"/>
       <text>Should not be choosable based on facts.</text>
         <line textSpeed="4" speakerId="ZUES">
           <text>text1 chosen.</text>
@@ -19,8 +19,8 @@
     </option>
 
     <option checkType="all" chooseCheckType="any">
-      <choiceCheck fact="FACT_CODE2" op="eq" val="1"/>
-      <displayCheck fact="FACT_CODE3" op="lte" val="1" />
+      <choiceCheck fact="fact_001" op="eq" val="1"/>
+      <displayCheck fact="fact_000" op="lte" val="1" />
       <text>displayed and choosable</text>
       <line textSpeed="4" speakerId="ZUES">
         <text textSpeed="2" speakerId="ZUES">line 1: option2 chosen.</text>

--- a/Assets/GameScript/Tests/check_events_fire_from_text.xml
+++ b/Assets/GameScript/Tests/check_events_fire_from_text.xml
@@ -1,0 +1,46 @@
+﻿<data>
+  <head>
+    <identifiers id="1" ref="ScriptExample.xml"/>
+    <tag ref="responses"/>
+    <!-- "tag" can be used as an easy include for intercutting lines-->
+    <include ref=""/>
+    <!-- should refer to includes by thier ref tag under identifiers -->
+    <includeTag ref="otherfile.xml" />
+    <OnEvent id="1"/>
+
+  </head>
+
+  <!-- id for dsets should be assigned by another tool. -->
+  <dialogue>
+    <!-- dset is a dialougue set. Group of dialouge related in some fashion -> a set of dialouge to play after a stat check, plays under a specific circumstance, etc -->
+    <!-- options for pulling the next tag: [sequential, random, wRandom] wRandom requires weights to be assigned to each line -->
+    <dset id="1" code="Human Readable name" pull="sequential" textSpeed="1" >
+
+      <!-- text speed not required here, but will override parent -->
+      <!-- playSound, playMusic, playAnim, prePuase optional -->
+      <!-- if "hasBeenPlayed is not specified, it's expected false. This will oly be updated via code"-->
+      <line textSpeed="2" speakerId="ZUES" playAnim="ZUES_SURP.anim" prePause ="0.1" hasBeenPlayed="true">
+        <text prePause="0.3" textSound="overideSpeakerTextSoundHere">
+          ONE:<i>amet</i>, consectetur <color hex="#AE1234">adipiscing</color> elit,
+        </text>
+        <text prePause="0" textSpeed="1" event="debug_empty|debugEmpty2">sed do eiusmod tempor incididunt ut labore...</text>
+      </line>
+
+      <!-- forceplay next will play the next line immediatley, without player action-->
+      <line textSpeed="2" speakerId="ZUES" playAnim="ZUES_SURP.anim" prePause ="0.1" forcePlayNext="true">
+        <text prePause="0.3" textSound="overideSpeakerTextSoundHere">
+          TWO: <i>amet</i>, consectetur <color hex="#AE1234">adipiscing</color> elit,
+        </text>
+        <text prePause="0" textSpeed="1">THREE:sed do eiusmod tempor incididunt ut labore...</text>
+      </line>
+
+
+      <line textSpeed="4" speakerId="MRGT">
+        <text>FOUR </text>
+        <text>FIVE</text>
+      </line>
+    </dset>
+  </dialogue>
+
+
+</data>

--- a/Assets/GameScript/Tests/check_events_fire_from_text.xml.meta
+++ b/Assets/GameScript/Tests/check_events_fire_from_text.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 070cc9a444e1f9543aea553bee1c82e4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -527,6 +527,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   audioManager: {fileID: 424580167}
+  eventsManager: {fileID: 2136117543}
   isWriting: 0
 --- !u!4 &874530471
 Transform:
@@ -672,3 +673,49 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2136117540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2136117542}
+  - component: {fileID: 2136117543}
+  m_Layer: 0
+  m_Name: EventsManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2136117542
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2136117540}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -12.606409, y: 3.4937544, z: -0.21187687}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2136117543
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2136117540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8094d3dd9fd73548a8b4fd6b122e76d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debugEvents:
+  - {fileID: 11400000, guid: 47cb5120de9fd4143b7c34c2871ba282, type: 2}

--- a/Assets/Scripts/Debug/SpeachTester.cs
+++ b/Assets/Scripts/Debug/SpeachTester.cs
@@ -16,7 +16,8 @@ public class SpeachTester : MonoBehaviour
         // SceneWeaver.GetInstance().LoadDialogueSet("Tests/TestFactsUpdateByLine_1");
         // SceneWeaver.GetInstance().LoadDialogueSet("Tests/TestChoicesAndLinesRender");
         // SceneWeaver.GetInstance().LoadDialogueSet("Tests/check_basic_line_ordering");
-        SceneWeaver.GetInstance().LoadDialogueSet("Tests/check_choices may_branch");
+        // SceneWeaver.GetInstance().LoadDialogueSet("Tests/check_choices may_branch");
+        SceneWeaver.GetInstance().LoadDialogueSet("Tests/check_events_fire_from_text");
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/GameEvents.meta
+++ b/Assets/Scripts/GameEvents.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd5c627b89836404ba2a7a8131b4be1a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameEvents/DebugEvents.meta
+++ b/Assets/Scripts/GameEvents/DebugEvents.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bb42cb76bd2f23c4a8259e7ebd7aa3d0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameEvents/DebugEvents/DebugEvent.cs
+++ b/Assets/Scripts/GameEvents/DebugEvents/DebugEvent.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Assets.Scripts.GameEvents.DebugEvents
+{
+    [CreateAssetMenu(fileName = "DebugEvent", menuName= "SceneWeaverEvents/DebugEventBasic")]
+    public class DebugEvent : SceneWeaverEvent
+    {
+        public string text;
+
+        public void OnEnable ()
+        {
+            base.OnExecute = () =>
+            {
+                Debug.Log(text);
+            };
+        }
+    }
+}

--- a/Assets/Scripts/GameEvents/DebugEvents/DebugEvent.cs.meta
+++ b/Assets/Scripts/GameEvents/DebugEvents/DebugEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 843ab1c1b623227488700206ecb63a52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameEvents/EventsManager.cs
+++ b/Assets/Scripts/GameEvents/EventsManager.cs
@@ -1,0 +1,35 @@
+using Assets.Scripts.GameEvents.DebugEvents;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+namespace Assets.Scripts.GameEvents {
+    public class EventsManager : MonoBehaviour
+    {
+        [SerializeField]
+        private List<DebugEvent> debugEvents;
+
+        Dictionary<string, SceneWeaverEvent> nameToEvent = new Dictionary<string, SceneWeaverEvent>();
+
+        private void Awake()
+        {
+           foreach(var debugEvent in debugEvents)
+            {
+                nameToEvent[debugEvent.eventName] = debugEvent;
+            }
+        }
+
+        public void PlayEvent(string name)
+        {
+            if (nameToEvent.ContainsKey(name))
+            {
+                this.nameToEvent[name].Execute();
+            } else
+            {
+                Debug.Log($"event {name} not added to event manager list");
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/GameEvents/EventsManager.cs.meta
+++ b/Assets/Scripts/GameEvents/EventsManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8094d3dd9fd73548a8b4fd6b122e76d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameEvents/SceneWeaverEvent.cs
+++ b/Assets/Scripts/GameEvents/SceneWeaverEvent.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Assets.Scripts.GameEvents
+
+{
+    public enum SceneWeaverEventType
+    {
+        Audio,
+        GameBG,
+        Character,
+        Transition
+    }
+
+   
+    public abstract class SceneWeaverEvent : ScriptableObject
+    {
+        
+        public string eventName;
+        public SceneWeaverEventType eventType { get; set; }
+        public delegate void EventAction();
+        public EventAction OnExecute;
+
+        public void Execute()
+        {
+            OnExecute?.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/GameEvents/SceneWeaverEvent.cs.meta
+++ b/Assets/Scripts/GameEvents/SceneWeaverEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ec97932ba66b784aa8732faa650514e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects.meta
+++ b/Assets/Scripts/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce558b0b35bfb384a8327385ed747ef8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Events.meta
+++ b/Assets/Scripts/ScriptableObjects/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 389c90e0e8dc187468dc47e35b3b6b99
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Events/Debug.meta
+++ b/Assets/Scripts/ScriptableObjects/Events/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ded2d4ea0fd31a4fb6d6c6492bacc7e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Events/Debug/debugEmpty2.asset
+++ b/Assets/Scripts/ScriptableObjects/Events/Debug/debugEmpty2.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 843ab1c1b623227488700206ecb63a52, type: 3}
+  m_Name: debugEmpty2
+  m_EditorClassIdentifier: 
+  eventName: debugEmpty2
+  text: debug2

--- a/Assets/Scripts/ScriptableObjects/Events/Debug/debugEmpty2.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Events/Debug/debugEmpty2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cff1f1d9842c57c4eb15857ba4f7e7a6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Events/Debug/debug_empty.asset
+++ b/Assets/Scripts/ScriptableObjects/Events/Debug/debug_empty.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 843ab1c1b623227488700206ecb63a52, type: 3}
+  m_Name: debug_empty
+  m_EditorClassIdentifier: 
+  eventName: debug_empty
+  text: benis

--- a/Assets/Scripts/ScriptableObjects/Events/Debug/debug_empty.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Events/Debug/debug_empty.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 47cb5120de9fd4143b7c34c2871ba282
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TextSystem/Models/Choices/OptionDialogueNode.cs
+++ b/Assets/Scripts/TextSystem/Models/Choices/OptionDialogueNode.cs
@@ -108,6 +108,11 @@ namespace Assets.Scripts.TextSystem.Choices
                 this.displayText = textNode.InnerText;
             }
 
+            foreach(XmlNode displayCheck in optionChildMap[Constants.DISPLAY_CHECK_TAG])
+            {
+                this.AddDisplayRule(new FactBasedTextRule(displayCheck.Attributes));
+            }
+
             // path nodes under this are handled identically to a branch, but require a wrapper.
             // uuuuuh wait this seems like a bad idea. We should have a branch wrapping the path like everything else.
             /*

--- a/Assets/Scripts/TextSystem/Models/Dialogue/TextBlock.cs
+++ b/Assets/Scripts/TextSystem/Models/Dialogue/TextBlock.cs
@@ -12,9 +12,11 @@ namespace Assets.Scripts.TextSystem.Models.Dialogue
         public string HexColor { get; private set; } // optional -> choose default 
         public string Text { get; private set; }
         public float? TextSpeed { get; private set; }
+        public List<string> Events { get; private set; }
 
         public TextBlock(XmlNode textNode)
         {
+            Events = new List<string>();
             if(textNode.Attributes["prePause"] != null)
             {
                 
@@ -23,6 +25,11 @@ namespace Assets.Scripts.TextSystem.Models.Dialogue
                     PrePause = prePause;
                 }
                     
+            }
+
+            if(textNode.Attributes["event"] != null)
+            {
+                Events = new List<string>(textNode.Attributes["event"].Value.Split('|'));
             }
 
             if (textNode.Attributes["textSpeed"] != null)

--- a/Assets/Scripts/TextSystem/SceneWeaver/TypeWriter.cs
+++ b/Assets/Scripts/TextSystem/SceneWeaver/TypeWriter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Assets.Scripts.GameEvents;
 using Assets.Scripts.Sound;
 using Assets.Scripts.Sound.Implementation;
 using Assets.Scripts.TextSystem.Models.Dialogue;
@@ -20,6 +21,8 @@ namespace Assets.Scripts.TextSystem.SceneWeaver
     {
         [SerializeField]
         private AudioController audioManager;
+        [SerializeField] 
+        private EventsManager eventsManager;
 
         float shownCharsInTextBlock = 0;
         private int textBlockIdx = 0;
@@ -35,6 +38,7 @@ namespace Assets.Scripts.TextSystem.SceneWeaver
         private UIController uiController;
         private DialogueLine currentLine;
         private StringBuilder sb = new StringBuilder();
+
 
         /// <summary>
         /// Each time this runs, it adds a SINGLE character. It also handles things like playing audio, pre-pauses for specific characters, etc.
@@ -95,7 +99,15 @@ namespace Assets.Scripts.TextSystem.SceneWeaver
 
                 // prioritize textBlock attributes, if specified.
                 textSpeed = currentLine.textBlocks[textBlockIdx].TextSpeed.HasValue ? currentLine.textBlocks[textBlockIdx].TextSpeed.Value : currentLine.TextSpeed;
+                if(currentLine.textBlocks[textBlockIdx].Events.Count > 0)
+                {
+                    foreach (var eventName in currentLine.textBlocks[textBlockIdx].Events)
+                    {
+                        eventsManager.PlayEvent(eventName);
+                    }
 
+                    // play event through handler.
+                }
                 StartCoroutine(TypeWriterTextRoutine(textSpeed));
             } else
             {
@@ -113,6 +125,15 @@ namespace Assets.Scripts.TextSystem.SceneWeaver
             textSpeed = line.textBlocks[textBlockIdx].TextSpeed.HasValue ? line.textBlocks[textBlockIdx].TextSpeed.Value : line.TextSpeed;
             // todo -> update the speaker on UI.
 
+            // textBlocks have events that play at the beginni
+            if(line.textBlocks[textBlockIdx].Events.Count > 0)
+            {
+                foreach (var eventName in currentLine.textBlocks[textBlockIdx].Events)
+                {
+                    Debug.Log("trying to play event");
+                    eventsManager.PlayEvent(eventName);
+                }
+            }
             StartCoroutine(TypeWriterTextRoutine(line.TextSpeed));
         }
 

--- a/Assets/Scripts/TextSystem/Utils/TextSystemUtils.cs
+++ b/Assets/Scripts/TextSystem/Utils/TextSystemUtils.cs
@@ -47,24 +47,26 @@ namespace Assets.Scripts.TextSystem.Utils
 
         public static bool CheckRules(List<FactBasedTextRule> rules, RuleCheckType checkType)
         {
+            if (checkType == RuleCheckType.noCheck) return true;
+
+            bool anyResult = false;
+            bool allResult = true;
             
             foreach(FactBasedTextRule rule in rules)
             {
 
-                if (checkType == RuleCheckType.noCheck)
+                if (checkType == RuleCheckType.any)
                 {
-                    return true;
+                    anyResult = CheckRule(rule) || anyResult;
+                }
                 
-                } else if (checkType == RuleCheckType.any && CheckRule(rule))
+                if(checkType == RuleCheckType.all)
                 {
-                    return true;
-                } else if(checkType == RuleCheckType.all && !CheckRule(rule))
-                {
-                    return false;
+                    anyResult = anyResult && CheckRule(rule);
                 }
             }
 
-            return true;
+            return checkType == RuleCheckType.any ? anyResult : allResult;
         }
         
         public static TextSystemEnums.RuleCheckType GetCheckType(string checkTypeVal)

--- a/Assets/Scripts/UI/Monobehaviors/UIController.cs
+++ b/Assets/Scripts/UI/Monobehaviors/UIController.cs
@@ -43,11 +43,6 @@ public class UIController : MonoBehaviour
         }
     }
 
-    public void InsertVisualElementIntoDialogueSecition(VisualElement element)
-    {
-        manager.InsertVisualElementIntoDialogueSecition(element);
-    }
-
     public void InsertNextDialogueElement(int dSetId)
     {
         if (typeWriter.isWriting || typeWriter.IsAwaitingChoice)

--- a/Assets/Scripts/UI/VisualElementRenderers/ChoiceRenderer.cs
+++ b/Assets/Scripts/UI/VisualElementRenderers/ChoiceRenderer.cs
@@ -99,7 +99,8 @@ namespace Assets.Scripts.UI.VisualElements
 
         public VisualElement GetVisualElement()
         {
-            if (element is null) BuildVisualElement();
+            // we rebuild the visual element on get. This handles conditional rendering for displaying choices.
+            BuildVisualElement();
             return element;
         }
 


### PR DESCRIPTION
One bugfix, the logic for checking any/all rules was just... wrong 😅.

On top of this, adds supports for firing events at the beginning of a text line. System uses Unity Scriptable objects that must be loaded into the EventManager within the unity UI. 